### PR TITLE
Parse LNURL to prevent the page from crashing

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ const Home: NextPage = () => {
   const [willShowQrCodeScanner, setWillShowQrCodeScanner] = useState(false);
   const [lnUrlOrAddress, setLnUrlOrAddress] = useState<string | undefined>();
   const router = useRouter();
-  const { isLnurl, isLightningAddress } = utils;
+  const { isLnurl, isLightningAddress, parseLnUrl } = utils;
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLnUrlOrAddress(e.currentTarget.lnUrlOrAddress.value.trim());
@@ -50,7 +50,9 @@ const Home: NextPage = () => {
     }
 
     setIsLoading(true);
-    router.push(`/${lnUrlOrAddress}`);
+
+    const lnurl = isLnurl(lnUrlOrAddress) ? parseLnUrl(lnUrlOrAddress) : lnUrlOrAddress;
+    router.push(`/${lnurl}`);
   }, [lnUrlOrAddress, isLnurl, isLightningAddress, router]);
 
   const baseUrl = useGetBaseUrl();


### PR DESCRIPTION
if the LNURL is embedded in an url, then the app crashes as it is passing the raw string to the next page.

**Example:**
- Paste the following url in https://www.lnurlpay.com/
- Click in the -> button

https://app.dfx.swiss/pl/?lightning=LNURL1DP68GURN8GHJ7CTSDYHXGENC9EEHW6TNWVHHVVF0D3H82UNVWQHHQMZLVFSKYV3CXQUN2DECVDSNJDMYXGWWJ2PQ

**Result:**
![Screenshot 2025-05-09 at 12 12 29 PM](https://github.com/user-attachments/assets/1bc802da-158b-4b07-b789-b8b86349766d)
